### PR TITLE
[feat] engine: implementation of cppreference

### DIFF
--- a/searx/engines/cppreference.py
+++ b/searx/engines/cppreference.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# lint: pylint
+"""Cppreference
+"""
+from lxml import html
+from searx.utils import eval_xpath
+
+about = {
+    "website": "https://en.cppreference.com/",
+    "wikidata_id": None,
+    "official_api_documentation": None,
+    "use_official_api": False,
+    "require_api_key": False,
+    "results": 'HTML',
+}
+
+categories = ['it']
+url = 'https://en.cppreference.com/'
+search_url = url + 'mwiki/index.php?title=Special%3ASearch&search={query}'
+
+def request(query, params):
+    params['url'] = search_url.format(query=query)
+    return query
+
+def response(resp):
+    results = []
+    # cppreference.com returns 404 if no results are found
+    dom = html.fromstring(resp.text)
+    for result in eval_xpath(dom, '//div[contains(@class, "mw-search-result-heading")]'):
+        results.append({
+            'url': url + eval_xpath(result, './/a/@href')[0],
+            'title': eval_xpath(result, './/a/text()')[0],
+              })
+    return results

--- a/searx/settings.yml
+++ b/searx/settings.yml
@@ -477,6 +477,11 @@ engines:
   #   # get your API key from: https://core.ac.uk/api-keys/register/
   #   api_key: 'unset'
 
+  - name: cppreference
+    engine: cppreference
+    shortcut: cpp
+    paging: false
+
   - name: crossref
     engine: crossref
     shortcut: cr


### PR DESCRIPTION
## What does this PR do?
Implement cppreference engine

## Why is this change important?
Search for C++ reference documentation

## How to test this PR locally?
Start dev server and search for `std::vector`, `std::string` or any other C++ reference

## Author's checklist
- [X] search functionality works

Also cppreference does support a bunch of other languages, but they aren't complete. Pages are missing, as well as content may be incomplete. I don't know any of those languages in there. Also I don't have any experience working with localization and stuff, would be nice if anyone else does take care of that.

## Related issues
None
